### PR TITLE
feat(api): force dynamic rooms route

### DIFF
--- a/app/api/rooms/route.ts
+++ b/app/api/rooms/route.ts
@@ -1,6 +1,8 @@
 import { type NextRequest, NextResponse } from "next/server"
 import { RoomService } from "@/lib/booking-service"
 
+export const dynamic = "force-dynamic"
+
 export async function GET() {
   try {
     const rooms = await RoomService.getRooms()


### PR DESCRIPTION
## Summary
- force dynamic rendering for rooms API to bypass Next.js caching

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `curl -sS http://localhost:3000/api/rooms` *(fails: {"success":false,"error":"Failed to fetch rooms"})*

------
https://chatgpt.com/codex/tasks/task_e_68a8a9474f688322ba65ec7fa7ec6309