### PR TITLE
Refresh room data after bookings

### DIFF
--- a/components/multi-step-booking.tsx
+++ b/components/multi-step-booking.tsx
@@ -12,6 +12,7 @@ import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover
 import { CalendarIcon, ChevronLeft, ChevronRight, Loader2 } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { useToast } from "@/components/ui/use-toast"
+import { useRooms } from "@/hooks/use-rooms"
 
 // Simple date formatting function to replace date-fns
 const format = (date: Date, formatStr: string) => {
@@ -82,6 +83,7 @@ export function MultiStepBooking() {
   const [roomPricing, setRoomPricing] = useState<RoomPricing[]>([])
   const [loadingRoomTypes, setLoadingRoomTypes] = useState(true)
   const { toast } = useToast()
+  const { fetchRooms: refreshRooms } = useRooms()
 
   const [bookingData, setBookingData] = useState<BookingData>({
     firstName: "",
@@ -377,6 +379,7 @@ export function MultiStepBooking() {
           title: "Booking Confirmed!",
           description: `Your booking reference is ${result.booking.booking_reference}`,
         })
+        await refreshRooms()
         setCurrentStep(5) // Success step
       } else {
         console.error("❌ Booking failed:", result)

--- a/hooks/use-rooms.ts
+++ b/hooks/use-rooms.ts
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback } from "react"
 import { toast } from "@/components/ui/use-toast"
+import { supabase } from "@/lib/supabase"
 
 export function useRooms() {
   const [rooms, setRooms] = useState([])
@@ -43,6 +44,35 @@ export function useRooms() {
 
   useEffect(() => {
     fetchRooms()
+  }, [fetchRooms])
+
+  useEffect(() => {
+    const roomsChannel = supabase
+      .channel("rooms_changes")
+      .on(
+        "postgres_changes",
+        { event: "*", schema: "public", table: "rooms" },
+        () => {
+          fetchRooms()
+        },
+      )
+      .subscribe()
+
+    const bookingsChannel = supabase
+      .channel("bookings_changes")
+      .on(
+        "postgres_changes",
+        { event: "*", schema: "public", table: "bookings" },
+        () => {
+          fetchRooms()
+        },
+      )
+      .subscribe()
+
+    return () => {
+      supabase.removeChannel(roomsChannel)
+      supabase.removeChannel(bookingsChannel)
+    }
   }, [fetchRooms])
 
   const createRoom = useCallback(async (roomData) => {


### PR DESCRIPTION
## Summary
- Trigger room list refresh after successful bookings
- Subscribe to Supabase realtime changes on rooms and bookings tables

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68a8a945725083229504c510809195db