### PR TITLE
Assign rooms during bookings and free on cancellation

### DIFF
--- a/hooks/use-bookings.ts
+++ b/hooks/use-bookings.ts
@@ -99,6 +99,18 @@ export function useBookings() {
 
       console.log("✅ Booking updated successfully:", data)
 
+      // If booking was cancelled or checked-out, mark room as available
+      if (updates.status && ["cancelled", "checked-out"].includes(updates.status) && data?.room_id) {
+        const { error: roomErr } = await supabase
+          .from("rooms")
+          .update({ status: "available" })
+          .eq("id", data.room_id)
+
+        if (roomErr) {
+          console.error("Error updating room status:", roomErr)
+        }
+      }
+
       // Refresh bookings list
       await fetchBookings()
 
@@ -136,6 +148,18 @@ export function useBookings() {
       }
 
       console.log("✅ Booking cancelled successfully:", data)
+
+      // Free up the room
+      if (data?.room_id) {
+        const { error: roomErr } = await supabase
+          .from("rooms")
+          .update({ status: "available" })
+          .eq("id", data.room_id)
+
+        if (roomErr) {
+          console.error("Error updating room status:", roomErr)
+        }
+      }
 
       // Refresh bookings list
       await fetchBookings()


### PR DESCRIPTION
## Summary
- Allocate first available room when creating a booking and mark it occupied
- Release room back to available status on checkout or cancellation
- Ensure client hooks mirror room-status updates

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint? exit 1)*

------
https://chatgpt.com/codex/tasks/task_e_68a8a9336f048322b74db0e382eb5e45